### PR TITLE
Add changes to authorize the subscribers page only to admin role

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,22 +6,32 @@ import ViewSubscribers from './pages/Admin/ViewSubscribers';
 import axios from 'axios';
 import './css/RecallList.css';
 import './css/App.css';
+import { currentUser } from './constants/userContext';
+import { switchRole } from './constants/userContext'; 
 
 function App() {
   return (
-    <Router>
+    <><Router>
       <nav style={{ padding: "1rem", borderBottom: "1px solid #ccc" }}>
         <Link to="/" style={{ marginRight: "1rem" }}>Home</Link>
         <Link to="/subscribe">Subscribe</Link>
-        <Link to="/admin/subscribers"> Admin</Link>
+        {currentUser.role === 'admin' && (
+          <Link to="/admin/subscribers"> Admin</Link>
+        )}
       </nav>
 
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/subscribe" element={<Subscribe />} />
-        <Route path="/admin/subscribers" element={<ViewSubscribers />} />
+        <Route path="/admin/subscribers" element={currentUser.role === 'admin' ? (
+          <ViewSubscribers />
+        ) : (<div>You do not have permission to view this page.</div>)} />
       </Routes>
     </Router>
+    <button onClick={() => switchRole(currentUser.role === 'admin' ? 'user' : 'admin')}>
+        Switch to {currentUser.role === 'admin' ? 'User' : 'Admin'}
+    </button>
+    </>
   );
 }
 

--- a/src/constants/userContext.js
+++ b/src/constants/userContext.js
@@ -1,0 +1,10 @@
+export const currentUser = JSON.parse(localStorage.getItem('currentUser')) || {
+    username: "admin_user",
+    role: "admin" //  change this to "user" for regular users
+};
+
+export const switchRole = (newRole) => {
+    const updatedUser = { ...currentUser, role: newRole};
+    localStorage.setItem('currentUser', JSON.stringify(updatedUser));
+    window.location.reload();
+}


### PR DESCRIPTION
This PR includes:
- Feature to authorize only the admin role to access the "Subscribers" page
- Add a button to switch between an admin and a regular user, for testing purposes as of now. Later, authorization will be added.
- The role is being stored in the local storage

<img width="1209" height="1017" alt="image" src="https://github.com/user-attachments/assets/f284975e-d862-4e66-b29f-0a0c8cabfa30" />
